### PR TITLE
ci(workflows): removes turbo-ignore command from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,48 +26,8 @@ jobs:
         run: |
           echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${{ github.ref_name }}^)" >> "$GITHUB_OUTPUT"
 
-  file-changes:
-    needs: [get-previous-tag]
-    runs-on: ubuntu-latest
-    outputs:
-      file-changes-backend: ${{ steps.file-changes-api.outputs.CONTINUE }}
-      file-changes-frontend: ${{ steps.file-changes-app.outputs.CONTINUE }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - id: file-changes-api
-        run: |
-          if pnpm dlx turbo-ignore --fallback ${{ needs.get-previous-tag.outputs.previous-tag }} @thoughts/api; then
-            echo "CONTINUE=0" >> "$GITHUB_OUTPUT"
-          else
-            echo "CONTINUE=1" >> "$GITHUB_OUTPUT"
-          fi
-
-      - id: file-changes-app
-        run: |
-          if pnpm dlx turbo-ignore --fallback ${{ needs.get-previous-tag.outputs.previous-tag }} @thoughts/app; then
-            echo "CONTINUE=0" >> "$GITHUB_OUTPUT"
-          else
-            echo "CONTINUE=1" >> "$GITHUB_OUTPUT"
-          fi
-
   push-frontend-docker-image:
-    needs: [file-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.file-changes.outputs.file-changes-frontend == '1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,9 +53,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/thoughts-frontend:latest
 
   push-backend-docker-image:
-    needs: [file-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.file-changes.outputs.file-changes-backend == '1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Removes turbo-ignore command from release workflow.
This means that both the API and App will be released every time, not dependent on rather or not the have changed.
